### PR TITLE
Make SimpleBotEvent callable (calling self.answer).

### DIFF
--- a/vkwave/bots/addons/easy/easy_handlers.py
+++ b/vkwave/bots/addons/easy/easy_handlers.py
@@ -66,6 +66,9 @@ class SimpleBotEvent(BotEvent):
     def __getitem__(self, key: typing.Any) -> typing.Any:
         return self.user_data[key]
 
+    async def __call__(self, **kwargs):
+        self.answer(**kwargs)
+
     async def answer(
         self,
         message: typing.Optional[str] = None,


### PR DESCRIPTION
Для удобства можно сделать SimpleBotEvent вызываемым, чтобы писать например не `await event.answer("...")`, а просто `await event(message="...")`
