### PR TITLE
Callback bot fix

### DIFF
--- a/vkwave/bots/addons/easy/base_easy_bot.py
+++ b/vkwave/bots/addons/easy/base_easy_bot.py
@@ -204,5 +204,5 @@ class BaseSimpleLongPollBot:
         self, ignore_errors: bool = True, loop: typing.Optional[asyncio.AbstractEventLoop] = None
     ):
         loop = loop or asyncio.get_event_loop()
-        loop.create_task(self.run(ignore_errors))
+        loop.create_task(self.run())
         loop.run_forever()

--- a/vkwave/bots/addons/easy/easy_bot.py
+++ b/vkwave/bots/addons/easy/easy_bot.py
@@ -52,3 +52,10 @@ class SimpleCallbackBot(BaseSimpleLongPollBot):
     async def run(self, ignore_errors: bool = True):
         await self.dispatcher.cache_potential_tokens()
         await self.cb_extension.start()
+
+    def run_forever(
+        self, ignore_errors: bool = True, loop: typing.Optional[asyncio.AbstractEventLoop] = None
+    ):
+        loop = loop or asyncio.get_event_loop()
+        loop.create_task(self.run())
+        loop.run_forever()


### PR DESCRIPTION
Переопределен метод run_forever для экземпляров класса SimpleCallbackBot. Теперь все работает как в примере из документации. Кеше привет.